### PR TITLE
Removes redundant definition

### DIFF
--- a/tasklib/lazy.py
+++ b/tasklib/lazy.py
@@ -36,9 +36,6 @@ class LazyUUIDTask(object):
             # For saved Tasks, just define equality by equality of uuids
             return self['uuid'] == other['uuid']
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
         return self['uuid'].__hash__()
 


### PR DESCRIPTION
\__ne__ is already defined if \__eq__ is defined

https://docs.python.org/3/reference/datamodel.html#object.__ne__