### PR TITLE
Added save_config method to taskwarrior backend

### DIFF
--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -8,7 +8,7 @@ import re
 import six
 import subprocess
 
-from .task import Task, TaskQuerySet, ReadOnlyDictView
+from .task import Task, TaskQuerySet
 from .filters import TaskWarriorFilter
 from .serializing import local_zone
 
@@ -266,7 +266,7 @@ class TaskWarrior(Backend):
                 config[match.group('key')] = match.group('value').strip()
 
         # Memoize the config dict
-        self._config = ReadOnlyDictView(config)
+        self._config = config
 
         return self._config
 
@@ -434,5 +434,5 @@ class TaskWarrior(Backend):
         'Overwrite the config file with the values of the self.config object'
 
         with open(self.taskrc_location, 'w') as f:
-            for key, value in sorted(self.config.viewed_dict.items()):
+            for key, value in sorted(self.config.items()):
                 f.write('{}={}\n'.format(key, value))

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -427,3 +427,10 @@ class TaskWarrior(Backend):
 
     def sync(self):
         self.execute_command(['sync'])
+
+    def save_config(self):
+        'Overwrite the config file with the values of the self.config object'
+
+        with open(self.taskrc_location, 'w') as f:
+            for key, value in sorted(self.config.viewed_dict.items()):
+                f.write('{}={}\n'.format(key, value))

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -259,6 +259,8 @@ class TaskWarrior(Backend):
         config_regex = re.compile(r'^(?P<key>[^\s]+)\s+(?P<value>[^\s].*$)')
 
         for line in raw_output:
+            if 'Some of your .taskrc' in line or 'Your .taskrc file' in line:
+                continue
             match = config_regex.match(line)
             if match:
                 config[match.group('key')] = match.group('value').strip()

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -1491,3 +1491,5 @@ class TaskWarriorBackendTest(TasklibTest):
             f_contents = f.read()
             assert 'default.command=next' in f_contents
             assert 'avoidlastcolumn=no\nbulk=0' in f_contents
+            assert 'Some=of your .taskrc variables differ from' + \
+                ' the default values.' not in f_contents

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import os
 import copy
 import datetime
 import itertools
@@ -1477,3 +1478,16 @@ class TaskWarriorBackendTest(TasklibTest):
         assert self.tw.config['nag'] == 'You have more urgent tasks.'
         assert self.tw.config['default.command'] == 'next'
         assert self.tw.config['dependency.indicator'] == 'D'
+
+    def test_config_save_ordered(self):
+        taskrc_path = os.path.join(self.tmp, 'taskrc')
+        open(taskrc_path, 'a').close()
+        self.tw = TaskWarrior(
+            data_location=self.tmp,
+            taskrc_location=taskrc_path,
+        )
+        self.tw.save_config()
+        with open(taskrc_path, 'r') as f:
+            f_contents = f.read()
+            assert 'default.command=next' in f_contents
+            assert 'avoidlastcolumn=no\nbulk=0' in f_contents


### PR DESCRIPTION
I've added the `save_config` method to the backend class so as to be able to save the config state loaded in tasklib into the taskrc path.

So as to be able to persist the changes made in the config by tasklib.

I've also found a bug in the `.config` property where it took the lines `Some of your .taskrc variables differ from the default values.` and `Your .taskrc file contains these unrecognized variables:` as valid configurations giving:

```python
self.config['Some'] == 'of your .taskrc variables differ from the default values.'
self.config['Your'] == '.taskrc file contains these unrecognized variables:'
```

`self.config` was set as an `ReadOnlyDictView` therefore I was unable to edit it on the fly, I've also converted it to a regular dictionary