### PR TITLE
Add support for custom `task` location or command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq build-essential cmake uuid-dev g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-  - git clone --recursive https://git.tasktools.org/TM/task
-  - cd task
+  - git clone --recursive https://github.com/GothenburgBitFactory/taskwarrior
+  - cd taskwarrior
   - git checkout $TASK_VERSION
   - git clean -dfx
   - git submodule init

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -95,7 +95,8 @@ class TaskWarrior(Backend):
     VERSION_2_4_5 = six.u('2.4.5')
 
     def __init__(self, data_location=None, create=True,
-                 taskrc_location=None, task_command='task'):
+                 taskrc_location=None, task_command='task',
+                 version_override=None):
         self.taskrc_location = None
         if taskrc_location:
             self.taskrc_location = os.path.expanduser(taskrc_location)
@@ -108,7 +109,7 @@ class TaskWarrior(Backend):
         self.task_command = task_command
 
         self._config = None
-        self.version = self._get_version()
+        self.version = version_override or self._get_version()
         self.overrides = {
             'confirmation': 'no',
             'dependency.confirmation': 'no',  # See TW-1483 or taskrc man page

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -47,12 +47,29 @@ def total_seconds_2_6(x):
 
 class TasklibTest(unittest.TestCase):
 
+    def get_taskwarrior(self, **kwargs):
+        tw_kwargs = dict(
+            data_location=self.tmp,
+            taskrc_location='/',
+        )
+        tw_kwargs.update(kwargs)
+        return TaskWarrior(**tw_kwargs)
+
     def setUp(self):
         self.tmp = tempfile.mkdtemp(dir='.')
-        self.tw = TaskWarrior(data_location=self.tmp, taskrc_location='/')
+        self.tw = self.get_taskwarrior()
 
     def tearDown(self):
         shutil.rmtree(self.tmp)
+
+
+class TaskWarriorTest(TasklibTest):
+
+    def test_custom_command(self):
+        # ensure that a custom command which contains multiple parts
+        # is properly split up
+        tw = self.get_taskwarrior(task_command='wsl task')
+        self.assertEqual(tw._get_task_command(), ['wsl', 'task'])
 
 
 class TaskFilterTest(TasklibTest):

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import itertools
 import json
+import os
 import pytz
 import six
 import shutil
@@ -68,7 +69,11 @@ class TaskWarriorTest(TasklibTest):
     def test_custom_command(self):
         # ensure that a custom command which contains multiple parts
         # is properly split up
-        tw = self.get_taskwarrior(task_command='wsl task')
+        tw = self.get_taskwarrior(
+            task_command='wsl task',
+            # prevent `_get_version` from running as `wsl` may not exist
+            version_override=os.getenv('TASK_VERSION'),
+        )
         self.assertEqual(tw._get_task_command(), ['wsl', 'task'])
 
 


### PR DESCRIPTION
Thanks @xarthurx for proposing WSL support in #62. This commit adds support in a different way, by allowing the "task" command to be customised (to `wsl task`, for example).