### PR TITLE
Fixes for python 3.8

### DIFF
--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -165,7 +165,7 @@ class TaskWarrior(Backend):
 
             # Empty values should not be enclosed in quotation marks, see
             # TW-1510
-            if serialized_value is '':
+            if serialized_value == '':
                 escaped_serialized_value = ''
             else:
                 escaped_serialized_value = six.u("'{0}'").format(

--- a/tasklib/lazy.py
+++ b/tasklib/lazy.py
@@ -19,7 +19,7 @@ class LazyUUIDTask(object):
 
     def __getitem__(self, key):
         # LazyUUIDTask does not provide anything else other than 'uuid'
-        if key is 'uuid':
+        if key == 'uuid':
             return self._uuid
         else:
             self.replace()

--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -125,7 +125,7 @@ class TaskResource(SerializingObject):
 
         # Empty string denotes empty serialized value, we do not want
         # to pass that to TaskWarrior.
-        data_tuples = filter(lambda t: t[1] is not '', data_tuples)
+        data_tuples = filter(lambda t: t[1] != '', data_tuples)
         data = dict(data_tuples)
         return json.dumps(data, separators=(',', ':'))
 
@@ -477,7 +477,7 @@ class TaskQuerySet(object):
 
     def __len__(self):
         if self._result_cache is None:
-            self._result_cache = list(self)
+            self._result_cache = list(self.__iter__())
         return len(self._result_cache)
 
     def __iter__(self):


### PR DESCRIPTION
Fixes #67 

Makes fixes for python 3.8.  In particular, fixes the SyntaxWarnings for "is" and "is not" comparisons with literals and the stack overflows when evaluating __len__() on TaskQuerySet.