### PR TITLE
Add `get_task` backend method with LRU cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 install_requirements = ['pytz', 'tzlocal']
 
-version = '2.0.0'
+version = '2.1.0'
 
 try:
     import importlib

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import subprocess
+from functools import lru_cache
 
 from .task import Task, TaskQuerySet, ReadOnlyDictView
 from .filters import TaskWarriorFilter
@@ -319,6 +320,10 @@ class TaskWarrior(Backend):
 
     def undo(self):
         self.execute_command(['undo'])
+
+    @lru_cache(maxsize=128)
+    def get_task(self, uuid):
+        return self.tasks.get(uuid=uuid)
 
     # Backend interface implementation
 

--- a/tasklib/lazy.py
+++ b/tasklib/lazy.py
@@ -71,8 +71,7 @@ class LazyUUIDTask(object):
         Performs conversion to the regular Task object, referenced by the
         stored UUID.
         """
-
-        replacement = self._tw.tasks.get(uuid=self._uuid)
+        replacement = self._tw.get_task(self._uuid)
         self.__class__ = replacement.__class__
         self.__dict__ = replacement.__dict__
 

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -144,6 +144,17 @@ class TaskFilterTest(TasklibTest):
         ).save()
         self.assertEqual(len(self.tw.tasks.recurring()), 1)
 
+    def test_get_task(self):
+        task = Task(self.tw, description='test task')
+        task.save()
+
+        fetched_task = self.tw.get_task(task['uuid'])
+        self.assertEqual(fetched_task, task)
+
+        # ensure `tw.tasks` is not queried as the task is cached
+        self.tw.tasks = None
+        self.tw.get_task(task['uuid'])
+
     def test_filtering_by_attribute(self):
         Task(self.tw, description='no priority task').save()
         Task(self.tw, priority='H', description='high priority task').save()


### PR DESCRIPTION
This allows a faster lookup of tasks by ID, avoiding the need to re-query taskwarrior for the same data.

Fixes https://github.com/robgolding/tasklib/issues/70