### PR TITLE
setup: Add __version__ attribute for the tasklib module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 install_requirements = ['pytz', 'tzlocal']
 
-version = '2.2.0'
+version = '2.2.1'
 
 try:
     import importlib

--- a/tasklib/__init__.py
+++ b/tasklib/__init__.py
@@ -1,3 +1,5 @@
 from .backends import TaskWarrior
 from .task import Task
 from .serializing import local_zone
+
+__version__ = '2.2.1'


### PR DESCRIPTION
Providing `__version__` attribute is a reasonably common convention among
packages in the Python ecosystem. Currently the only other reliable
alternative is to use pkg_resources.get_distribution method, however,
importing pkg_resources is notoriously slow [1,2].

Provide the `__version__` attribute to provide an API interface to check
the version of tasklib at runtime.

Bump the version in order to reflect module API change.

[1] https://github.com/pypa/setuptools/issues/510
[2] https://github.com/pypa/setuptools/issues/926