### PR TITLE
Support eoy definition in taskwarrior 2.5.2 (Closes: #87)

### DIFF
--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -1229,13 +1229,22 @@ class DatetimeStringTest(TasklibTest):
         t = Task(self.tw, description='test task', due='eoy')
         now = local_zone.localize(datetime.datetime.now())
         eoy = local_zone.localize(datetime.datetime(
-            year=now.year,
-            month=12,
-            day=31,
-            hour=23,
-            minute=59,
-            second=59,
+            year=now.year+1,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=0,
             ))
+        if self.tw.version < '2.5.2':
+            eoy = local_zone.localize(datetime.datetime(
+                year=now.year,
+                month=12,
+                day=31,
+                hour=23,
+                minute=59,
+                second=59,
+                ))
         self.assertEqual(eoy, t['due'])
 
     def test_complex_eoy_conversion(self):
@@ -1251,14 +1260,25 @@ class DatetimeStringTest(TasklibTest):
         now = local_zone.localize(datetime.datetime.now())
         due_date = local_zone.localize(
             datetime.datetime(
-                year=now.year,
-                month=12,
-                day=31,
-                hour=23,
-                minute=59,
-                second=59,
+                year=now.year+1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
             )
         ) - datetime.timedelta(0, 4 * 30 * 86400)
+        if self.tw.version < '2.5.2':
+            due_date = local_zone.localize(
+                datetime.datetime(
+                    year=now.year,
+                    month=12,
+                    day=31,
+                    hour=23,
+                    minute=59,
+                    second=59,
+                )
+            ) - datetime.timedelta(0, 4 * 30 * 86400)
         self.assertEqual(due_date, t['due'])
 
     def test_filtering_with_string_datetime(self):


### PR DESCRIPTION
taskwarrior 2.5.2 switched the end of year definition:

$ task calc eoy
2000-12-31T23:59:59 (version 2.5.1)
2021-01-01T00:00:00 (version 2.5.2)