### PR TITLE
Fix unit tests on non wsl non Travis systems

### DIFF
--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -72,7 +72,7 @@ class TaskWarriorTest(TasklibTest):
         tw = self.get_taskwarrior(
             task_command='wsl task',
             # prevent `_get_version` from running as `wsl` may not exist
-            version_override=os.getenv('TASK_VERSION'),
+            version_override=os.getenv('TASK_VERSION', 'v1.2.3'),
         )
         self.assertEqual(tw._get_task_command(), ['wsl', 'task'])
 


### PR DESCRIPTION
The test_custom_command was introduced in #63 with the TASK_VERSION for
Travis. As TASK_VERSION is not part of a default environment, the test
would still try to run `wsl` on other systems and fail.